### PR TITLE
fix false diff on prefix log types

### DIFF
--- a/internal/provider/resource_s3_source.go
+++ b/internal/provider/resource_s3_source.go
@@ -319,7 +319,8 @@ func prefixLogTypesToInput(prefixLogTypes []PrefixLogTypesModel) []client.S3Pref
 func prefixLogTypesToModel(prefixLogTypes []client.S3PrefixLogTypes) []PrefixLogTypesModel {
 	result := []PrefixLogTypesModel{}
 	for _, p := range prefixLogTypes {
-		var excluded, logTypes []types.String
+		excluded := []types.String{}
+		logTypes := []types.String{}
 		for _, v := range p.ExcludedPrefixes {
 			excluded = append(excluded, types.StringValue(v))
 		}


### PR DESCRIPTION
### Background

TF S3 Source resource would always detect a change in the excluded prefixes, by comparing an empty list to a null list.

### Changes

* initialize excluded prefix / log types array so that they are compared correctly

