### PR TITLE
Fix false attribute changes around kms_key field

### DIFF
--- a/internal/client/panther.go
+++ b/internal/client/panther.go
@@ -83,7 +83,7 @@ type S3LogIntegration struct {
 	// True if the Log Source can be modified
 	IsEditable bool `graphql:"isEditable"`
 	// KMS key used to access the S3 Bucket
-	KmsKey *string `graphql:"kmsKey"`
+	KmsKey string `graphql:"kmsKey"`
 	// The AWS Role used to access the S3 Bucket
 	LogProcessingRole *string `graphql:"logProcessingRole"`
 	// The format of the log files being ingested

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -70,7 +70,6 @@ func (p *PantherProvider) Schema(ctx context.Context, req provider.SchemaRequest
 
 func (p *PantherProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
 	var data PantherProviderModel
-
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/resource_s3_source.go
+++ b/internal/provider/resource_s3_source.go
@@ -27,6 +27,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -86,6 +87,8 @@ func (r *S3SourceResource) Schema(ctx context.Context, req resource.SchemaReques
 			"kms_key_arn": schema.StringAttribute{
 				Description: "The KMS key ARN used to access the S3 Bucket.",
 				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(""),
 			},
 			"name": schema.StringAttribute{
 				Description: "The display name of the S3 Log Source integration.",
@@ -232,9 +235,10 @@ func (r *S3SourceResource) Read(ctx context.Context, req resource.ReadRequest, r
 		)
 		return
 	}
+
 	data.Id = types.StringValue(source.IntegrationID)
 	data.AWSAccountID = types.StringValue(source.AwsAccountID)
-	data.KMSKeyARN = types.StringPointerValue(source.KmsKey)
+	data.KMSKeyARN = types.StringValue(source.KmsKey)
 	data.Name = types.StringValue(source.IntegrationLabel)
 	data.LogProcessingRoleARN = types.StringPointerValue(source.LogProcessingRole)
 	data.LogStreamType = types.StringPointerValue(source.LogStreamType)


### PR DESCRIPTION
### Background

We were seeing an issue where an S3 resource would be updated in place even if there were no changes.  This was due to kms_key being resolved to an empty string or a null value depending on context.  We're going to treat this as a normal string now and default it to "".

### Changes

* kms_key no longer string pointer type

### Testing

* Manually tested
* ran E2E tests through `make testacc`

