### PR TITLE
Allow 'Auto' as value for log_stream_type

### DIFF
--- a/internal/provider/resource_s3_source.go
+++ b/internal/provider/resource_s3_source.go
@@ -109,7 +109,7 @@ func (r *S3SourceResource) Schema(ctx context.Context, req resource.SchemaReques
 				Description: "The format of the log files being ingested.",
 				Required:    true,
 				Validators: []validator.String{
-					stringvalidator.OneOf("Lines", "JSON", "JsonArray", "CloudWatchLogs"),
+					stringvalidator.OneOf("Auto", "Lines", "JSON", "JsonArray", "CloudWatchLogs"),
 				},
 			},
 			"panther_managed_bucket_notifications_enabled": schema.BoolAttribute{


### PR DESCRIPTION
### Background

Panther UI allows 'Auto' as value for log format (`log_stream_type`):
![image](https://github.com/panther-labs/terraform-provider-panther/assets/20437/c816c029-bc2c-4b84-8c57-0dc2f3fb68d6)

If this format is changed in UI, the terraform state then becomes dirty and if we try to change the value to `"Auto"` in the resource, we get the following error:

```text
╷
│ Error: Invalid Attribute Value Match
│
│   with panther_s3_source.my_cool_source,
│   on panther.tf line 127, in resource "panther_s3_source" "my_cool_source":
│  127:   log_stream_type                              = "Auto"
│
│ Attribute log_stream_type value must be one of: ["\"Lines\"" "\"JSON\"" "\"JsonArray\"" "\"CloudWatchLogs\""], got: "Auto"
```

At the same type the GraphQL schema ([docs](https://docs.panther.com/panther-developer-workflows/api/graphql), [schema](https://panther-community-us-east-1.s3.amazonaws.com/latest/graphql/schema.public.graphql)) used by the provider allows `"Auto"` value. It also returns it, hence the diff in terraform state:

```text
Terraform will perform the following actions:

  # panther_s3_source.my_cool_source will be updated in-place
  ~ resource "panther_s3_source" "my_cool_source" {
        id                                           = "..."
      ~ log_stream_type                              = "Auto" -> "JSON"
        name                                         = "my_cool"
        # (6 unchanged attributes hidden)
    }
```

### Changes

Allow `"Auto"` value during validation stage.

### Testing

Steps more or less described in Background section.

