### PR TITLE
Use harden-runner Action for all Workflows

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,11 +5,16 @@ on:
     branches:
       - '*'
 
-jobs:
+permissions:
+  contents: read
 
+jobs:
   build_and_test:
     runs-on: ubuntu-latest
     steps:
+    - uses: step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10 # v2.8.0
+      with:
+        egress-policy: audit
     - uses: actions/checkout@v3
 
     - name: Set up Go

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,16 @@ jobs:
     steps:
     - uses: step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10 # v2.8.0
       with:
-        egress-policy: audit
+        disable-sudo: true
+        egress-policy: block
+        allowed-endpoints: >
+          api.github.com:443
+          checkpoint-api.hashicorp.com:443
+          github.com:443
+          objects.githubusercontent.com:443
+          proxy.golang.org:443
+          storage.googleapis.com:443
+  
     - uses: actions/checkout@v3
 
     - name: Set up Go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,9 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
+      - uses: step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10 # v2.8.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
           # Allow goreleaser to access older tag information.


### PR DESCRIPTION
### Background

Relates to EPD-368

This PR adds StepSecurity's `harden-runners` Action to all of our Workflows. 

We'll run egress blocks for Workflows that can be validated within a PR and audits for the other Workflows. Once the latter run at least once, we can implement the recommendations in a follow-up PR.

### Changes

- Adds the `harden-runner` Action to all Workflows

### Testing

- Checks pass as expected