### PR TITLE
Use full Action SHAs rather than versioned releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+
+updates:
+  # Update the GitHub actions used in our CI/CD workflow
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "@panther-labs/admin"
+    assignees:
+      - "@panther-labs/admin"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,10 +24,10 @@ jobs:
           proxy.golang.org:443
           storage.googleapis.com:443
   
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7
       with:
         go-version: 1.19
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,22 +20,22 @@ jobs:
       - uses: step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10 # v2.8.0
         with:
           egress-policy: audit
-      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
         with:
           # Allow goreleaser to access older tag information.
           fetch-depth: 0
-      - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+      - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7
         with:
           go-version-file: 'go.mod'
           cache: true
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@72b6676b71ab476b77e676928516f6982eef7a41 # v5.3.0
+        uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4
         id: import_gpg
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@336e29918d653399e599bfca99fadc1d7ffbc9f7 # v4.3.0
+        uses: goreleaser/goreleaser-action@5742e2a039330cbb23ebf35f046f814d4c6ff811
         with:
           args: release --clean
         env:


### PR DESCRIPTION
### Background

Relates to: EPD-370

Pinning Action versions to the full SHA rather than the version is a best practice from a supply chain security perspective. Dependabot will handle any updates for us.

### Changes

* Moves all Actions to their latest respective commit SHA

### Testing

* Checks still pass as expected