### PR TITLE
Update panther url

### DIFF
--- a/internal/client/panther/panther.go
+++ b/internal/client/panther/panther.go
@@ -27,8 +27,8 @@ import (
 	"terraform-provider-panther/internal/client"
 )
 
-const GraphqlPath = "/v1/public/graphql"
-const RestHttpSourcePath = "/v1/log-sources/http"
+const GraphqlPath = "/public/graphql"
+const RestHttpSourcePath = "/log-sources/http"
 
 var _ client.GraphQLClient = (*GraphQLClient)(nil)
 

--- a/internal/client/panther/panther.go
+++ b/internal/client/panther/panther.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hasura/go-graphql-client"
 	"io"
 	"net/http"
+	"strings"
 	"terraform-provider-panther/internal/client"
 )
 
@@ -72,6 +73,16 @@ func NewAPIClient(graphClient *GraphQLClient, restClient *RestClient) *APIClient
 		graphClient,
 		restClient,
 	}
+}
+
+func CreateAPIClient(url, token string) *APIClient {
+	// url in previous versions was provided including graphql endpoint,
+	// we strip it here to keep it backwards compatible
+	pantherUrl := strings.TrimSuffix(url, GraphqlPath)
+	graphClient := NewGraphQLClient(pantherUrl, token)
+	restClient := NewRestClient(pantherUrl, token)
+
+	return NewAPIClient(graphClient, restClient)
 }
 
 func (c *RestClient) CreateHttpSource(ctx context.Context, input client.CreateHttpSourceInput) (client.HttpSource, error) {

--- a/internal/client/panther/panther_test.go
+++ b/internal/client/panther/panther_test.go
@@ -1,0 +1,43 @@
+package panther
+
+import (
+	"github.com/stretchr/testify/assert"
+	"reflect"
+	"testing"
+)
+
+// Saas customer which provides the graphql endpoint (legacy behavior)
+func TestCreateAPIClient_SaasGraphEndpoint(t *testing.T) {
+	url := "panther-url/public/graphql"
+	client := *CreateAPIClient(url, "token")
+	graphUrl := reflect.ValueOf(client).FieldByIndex([]int{0}).Elem().FieldByName("url").String()
+	assert.Equal(t, "panther-url/public/graphql", graphUrl)
+	assert.Equal(t, "panther-url/log-sources/http", client.RestClient.url)
+}
+
+// Saas customer which provides the panther root url (new behavior)
+func TestCreateAPIClient_SaasBaseURL(t *testing.T) {
+	url := "panther-url"
+	client := *CreateAPIClient(url, "token")
+	graphUrl := reflect.ValueOf(client).FieldByIndex([]int{0}).Elem().FieldByName("url").String()
+	assert.Equal(t, "panther-url/public/graphql", graphUrl)
+	assert.Equal(t, "panther-url/log-sources/http", client.RestClient.url)
+}
+
+// Cloud Connected/Self-hosted customer which provides the graphql endpoint (legacy behavior)
+func TestCreateAPIClient_CCGraphEndpoint(t *testing.T) {
+	url := "panther-url/v1/public/graphql"
+	client := *CreateAPIClient(url, "token")
+	graphUrl := reflect.ValueOf(client).FieldByIndex([]int{0}).Elem().FieldByName("url").String()
+	assert.Equal(t, "panther-url/v1/public/graphql", graphUrl)
+	assert.Equal(t, "panther-url/v1/log-sources/http", client.RestClient.url)
+}
+
+// Cloud Connected/Self-hosted customer which provides the panther root url (new behavior)
+func TestCreateAPIClient_CCBaseURL(t *testing.T) {
+	url := "panther-url/v1"
+	client := *CreateAPIClient(url, "token")
+	graphUrl := reflect.ValueOf(client).FieldByIndex([]int{0}).Elem().FieldByName("url").String()
+	assert.Equal(t, "panther-url/v1/public/graphql", graphUrl)
+	assert.Equal(t, "panther-url/v1/log-sources/http", client.RestClient.url)
+}

--- a/internal/client/panther/panther_test.go
+++ b/internal/client/panther/panther_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 )
 
-// Saas customer which provides the graphql endpoint (legacy behavior)
-func TestCreateAPIClient_SaasGraphEndpoint(t *testing.T) {
+// Customer with custom url that provides the graphql endpoint (legacy behavior)
+func TestCreateAPIClient_CustomURLWithGraphEndpoint(t *testing.T) {
 	url := "panther-url/public/graphql"
 	client := *CreateAPIClient(url, "token")
 	graphUrl := reflect.ValueOf(client).FieldByIndex([]int{0}).Elem().FieldByName("url").String()
@@ -15,8 +15,8 @@ func TestCreateAPIClient_SaasGraphEndpoint(t *testing.T) {
 	assert.Equal(t, "panther-url/log-sources/http", client.RestClient.url)
 }
 
-// Saas customer which provides the panther root url (new behavior)
-func TestCreateAPIClient_SaasBaseURL(t *testing.T) {
+// Customer with custom url that provides the panther root url (new behavior)
+func TestCreateAPIClient_CustomUrlWithBaseUrl(t *testing.T) {
 	url := "panther-url"
 	client := *CreateAPIClient(url, "token")
 	graphUrl := reflect.ValueOf(client).FieldByIndex([]int{0}).Elem().FieldByName("url").String()
@@ -24,8 +24,8 @@ func TestCreateAPIClient_SaasBaseURL(t *testing.T) {
 	assert.Equal(t, "panther-url/log-sources/http", client.RestClient.url)
 }
 
-// Cloud Connected/Self-hosted customer which provides the graphql endpoint (legacy behavior)
-func TestCreateAPIClient_CCGraphEndpoint(t *testing.T) {
+// Customer with API Gateway url that provides the graphql endpoint (legacy behavior)
+func TestCreateAPIClient_ApiGWUrlWithGraphEndpoint(t *testing.T) {
 	url := "panther-url/v1/public/graphql"
 	client := *CreateAPIClient(url, "token")
 	graphUrl := reflect.ValueOf(client).FieldByIndex([]int{0}).Elem().FieldByName("url").String()
@@ -33,8 +33,8 @@ func TestCreateAPIClient_CCGraphEndpoint(t *testing.T) {
 	assert.Equal(t, "panther-url/v1/log-sources/http", client.RestClient.url)
 }
 
-// Cloud Connected/Self-hosted customer which provides the panther root url (new behavior)
-func TestCreateAPIClient_CCBaseURL(t *testing.T) {
+// Customer with API Gateway url that provides the panther root url (new behavior)
+func TestCreateAPIClient_ApiGWUrlWithBaseUrl(t *testing.T) {
 	url := "panther-url/v1"
 	client := *CreateAPIClient(url, "token")
 	graphUrl := reflect.ValueOf(client).FieldByIndex([]int{0}).Elem().FieldByName("url").String()

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -19,8 +19,6 @@ package provider
 import (
 	"context"
 	"os"
-	"strings"
-
 	"terraform-provider-panther/internal/client/panther"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -124,13 +122,7 @@ func (p *PantherProvider) Configure(ctx context.Context, req provider.ConfigureR
 		return
 	}
 
-	// url in previous versions was provided including graphql endpoint,
-	// we strip it here to keep it backwards compatible
-	pantherUrl := strings.TrimSuffix(url, panther.GraphqlPath)
-	graphClient := panther.NewGraphQLClient(pantherUrl, token)
-	restClient := panther.NewRestClient(pantherUrl, token)
-
-	resp.ResourceData = panther.NewAPIClient(graphClient, restClient)
+	resp.ResourceData = panther.CreateAPIClient(url, token)
 
 }
 


### PR DESCRIPTION
### Background

Based on the [docs](https://docs.panther.com/panther-developer-workflows/api/rest), customers have two different types of urls, either a custom base url, or a url which comes from the api gateway, which includes a `/v1`. For accessing the graph or the rest api, `/public/graphql` or the specific rest endpoint, in our case `log-sources/http` is appended.

### Changes

The current code, in order to be backwards compatible for customers who provide a graphql url rather than the root url, as it was the case when we only had s3 resource, is performing manipulation in the url. However, this is based on the url containing `/v1`, so it will not work for customers with a custom url. This PR fixes that.

### Testing

Added unit tests for all possible cases
* <Testing steps>

