### PR TITLE
switch panther provider registry asset owner

### DIFF
--- a/.terraform-registry
+++ b/.terraform-registry
@@ -1,4 +1,3 @@
 Request: change owner to le4ker
 Registry link: https://registry.terraform.io/providers/panther-labs/panther/latest
 Request by: panos.sakkos@panther.com
-

--- a/examples/full-examples/http-log-source/.terraform-registry
+++ b/examples/full-examples/http-log-source/.terraform-registry
@@ -1,0 +1,4 @@
+Request: change owner to le4ker
+Registry link: https://registry.terraform.io/providers/panther-labs/panther/latest
+Request by: panos.sakkos@panther.com
+


### PR DESCRIPTION
### Background

Message from hashicorp:
```
We can have a new owner for the asset, unfortunately it's just one user, for that we require confirmation of your genuine ownership and control over the asset's GitHub repository to assist you with this request. You can establish this by following these steps:

Create a new file named ".terraform-registry" in the repository's root directory on the default branch.
Inside this file, include the following content: Request: <concisely explain your request, i.e., "change owner to GitHub username" > Registry Link: <link to your asset on the Registry> Request by: <the email associated with this request> If you have any questions or encounter any issues during this process, please feel free to reach out for further assistance.
```

### Changes

Switch owner of Panther provider in hashicorp registry to Panos.

### Testing

* <Testing steps>

