### PR TITLE
add logstreamtypeoptions field to http resource

### DIFF
--- a/docs/resources/httpsource.md
+++ b/docs/resources/httpsource.md
@@ -47,3 +47,11 @@ resource "panther_httpsource" "example_http_source" {
 - `auth_secret_value` (String) The authentication header secret value of the http source. Used for HMAC and SharedSecret auth methods
 - `auth_username` (String) The authentication header username of the http source. Used for Basic auth method
 - `id` (String) ID of the http source to fetch
+- `log_stream_type_options` (Attributes) (see [below for nested schema](#nestedatt--log_stream_type_options))
+
+<a id="nestedatt--log_stream_type_options"></a>
+### Nested Schema for `log_stream_type_options`
+
+Optional:
+
+- `json_array_envelope_field` (String) Path to the array value to extract elements from, only applicable if logStreamType is JsonArray. Leave empty if the input JSON is an array itself

--- a/examples/full-examples/http-log-source/http-log-source.tf
+++ b/examples/full-examples/http-log-source/http-log-source.tf
@@ -1,11 +1,11 @@
 resource "panther_httpsource" "example_http_source" {
-  integration_label       = var.integration_label
-  log_stream_type         = var.log_stream_type
-  log_types               = var.log_types
-  auth_method             = var.auth_method
-  auth_header_key         = var.auth_header_key
-  auth_secret_value       = var.auth_secret_value
- log_stream_type_options = {
-   json_array_envelope_field = var.json_array_envelope_field
- }
+  integration_label = var.integration_label
+  log_stream_type   = var.log_stream_type
+  log_types         = var.log_types
+  auth_method       = var.auth_method
+  auth_header_key   = var.auth_header_key
+  auth_secret_value = var.auth_secret_value
+  log_stream_type_options = {
+    json_array_envelope_field = var.json_array_envelope_field
+  }
 }

--- a/examples/full-examples/http-log-source/http-log-source.tf
+++ b/examples/full-examples/http-log-source/http-log-source.tf
@@ -1,8 +1,11 @@
 resource "panther_httpsource" "example_http_source" {
-  integration_label = var.integration_label
-  log_stream_type   = var.log_stream_type
-  log_types         = var.log_types
-  auth_method       = var.auth_method
-  auth_header_key   = var.auth_header_key
-  auth_secret_value = var.auth_secret_value
+  integration_label       = var.integration_label
+  log_stream_type         = var.log_stream_type
+  log_types               = var.log_types
+  auth_method             = var.auth_method
+  auth_header_key         = var.auth_header_key
+  auth_secret_value       = var.auth_secret_value
+ log_stream_type_options = {
+   json_array_envelope_field = var.json_array_envelope_field
+ }
 }

--- a/examples/full-examples/http-log-source/main.tf
+++ b/examples/full-examples/http-log-source/main.tf
@@ -3,6 +3,7 @@ terraform {
   required_providers {
     panther = {
       source = "panther-labs/panther"
+      version = ">=0.2.4"
     }
   }
 }

--- a/examples/full-examples/http-log-source/main.tf
+++ b/examples/full-examples/http-log-source/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 1.0"
   required_providers {
     panther = {
-      source = "panther-labs/panther"
+      source  = "panther-labs/panther"
       version = ">=0.2.4"
     }
   }

--- a/examples/full-examples/http-log-source/variables.tf
+++ b/examples/full-examples/http-log-source/variables.tf
@@ -38,3 +38,8 @@ variable "auth_secret_value" {
   type        = string
   sensitive   = true
 }
+
+variable "json_array_envelope_field" {
+  description = "Envelope field for json array stream"
+  type        = string
+}

--- a/internal/client/panther.go
+++ b/internal/client/panther.go
@@ -129,18 +129,24 @@ type HttpSource struct {
 	HttpSourceModifiableAttributes
 }
 
+// LogStreamTypeOptions contains options specific to the log stream type
+type LogStreamTypeOptions struct {
+	JsonArrayEnvelopeField string `json:"jsonArrayEnvelopeField,omitempty"`
+}
+
 // HttpSourceModifiableAttributes attributes that can be modified on an http log source
 type HttpSourceModifiableAttributes struct {
-	IntegrationLabel string
-	LogStreamType    string
-	LogTypes         []string
-	AuthHmacAlg      string
-	AuthHeaderKey    string
-	AuthPassword     string
-	AuthSecretValue  string
-	AuthMethod       string
-	AuthUsername     string
-	AuthBearerToken  string
+	IntegrationLabel     string
+	LogStreamType        string
+	LogTypes             []string
+	LogStreamTypeOptions *LogStreamTypeOptions `json:"logStreamTypeOptions,omitempty"`
+	AuthHmacAlg          string
+	AuthHeaderKey        string
+	AuthPassword         string
+	AuthSecretValue      string
+	AuthMethod           string
+	AuthUsername         string
+	AuthBearerToken      string
 }
 
 // CreateHttpSourceInput Input for creating an http log source

--- a/internal/client/panther.go
+++ b/internal/client/panther.go
@@ -131,7 +131,7 @@ type HttpSource struct {
 
 // LogStreamTypeOptions contains options specific to the log stream type
 type LogStreamTypeOptions struct {
-	JsonArrayEnvelopeField string `json:"jsonArrayEnvelopeField,omitempty"`
+	JsonArrayEnvelopeField string
 }
 
 // HttpSourceModifiableAttributes attributes that can be modified on an http log source
@@ -139,7 +139,7 @@ type HttpSourceModifiableAttributes struct {
 	IntegrationLabel     string
 	LogStreamType        string
 	LogTypes             []string
-	LogStreamTypeOptions *LogStreamTypeOptions `json:"logStreamTypeOptions,omitempty"`
+	LogStreamTypeOptions *LogStreamTypeOptions
 	AuthHmacAlg          string
 	AuthHeaderKey        string
 	AuthPassword         string

--- a/internal/provider/httpsource_resource.go
+++ b/internal/provider/httpsource_resource.go
@@ -19,17 +19,20 @@ package provider
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/path"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"terraform-provider-panther/internal/client"
 	"terraform-provider-panther/internal/client/panther"
 	"terraform-provider-panther/internal/provider/resource_httpsource"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -82,6 +85,18 @@ func (r *httpsourceResource) Schema(ctx context.Context, req resource.SchemaRequ
 	bearerToken := resp.Schema.Attributes["auth_bearer_token"].(schema.StringAttribute)
 	bearerToken.Default = stringdefault.StaticString("")
 	resp.Schema.Attributes["auth_bearer_token"] = bearerToken
+
+	// Get the nested attribute
+	logStreamTypeOptions := resp.Schema.Attributes["log_stream_type_options"].(schema.SingleNestedAttribute)
+
+	// Set a null default using objectdefault.StaticValue
+	logStreamTypeOptions.Default = objectdefault.StaticValue(types.ObjectNull(
+		map[string]attr.Type{
+			"json_array_envelope_field": types.StringType,
+		},
+	))
+
+	resp.Schema.Attributes["log_stream_type_options"] = logStreamTypeOptions
 }
 
 func (r *httpsourceResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
@@ -112,18 +127,42 @@ func (r *httpsourceResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
+	// Log the input data
+	tflog.Warn(ctx, "Creating HTTP Source", map[string]interface{}{
+		"INTEGRATION_LABEL":               data.IntegrationLabel.ValueString(),
+		"LOG_STREAM_TYPE":                 data.LogStreamType.ValueString(),
+		"LOG_STREAM_TYPE_OPTIONS":         fmt.Sprintf("%+v", data.LogStreamTypeOptions),
+		"LOG_STREAM_TYPE_OPTIONS_NULL":    data.LogStreamTypeOptions.IsNull(),
+		"LOG_STREAM_TYPE_OPTIONS_UNKNOWN": data.LogStreamTypeOptions.IsUnknown(),
+	})
+
+	// Create LogStreamTypeOptions if it's provided
+	var logStreamTypeOptions *client.LogStreamTypeOptions
+	if !data.LogStreamTypeOptions.IsNull() && !data.LogStreamTypeOptions.IsUnknown() {
+		logStreamTypeOptions = &client.LogStreamTypeOptions{
+			JsonArrayEnvelopeField: data.LogStreamTypeOptions.JsonArrayEnvelopeField.ValueString(),
+		}
+
+		tflog.Warn(ctx, "Setting LogStreamTypeOptions", map[string]interface{}{
+			"JSON_ARRAY_ENVELOPE_FIELD": data.LogStreamTypeOptions.JsonArrayEnvelopeField.ValueString(),
+		})
+	} else {
+		tflog.Warn(ctx, "LogStreamTypeOptions is null or unknown, not setting")
+	}
+
 	httpSource, err := r.client.CreateHttpSource(ctx, client.CreateHttpSourceInput{
 		HttpSourceModifiableAttributes: client.HttpSourceModifiableAttributes{
-			IntegrationLabel: data.IntegrationLabel.ValueString(),
-			LogStreamType:    data.LogStreamType.ValueString(),
-			LogTypes:         convertLogTypes(ctx, data.LogTypes),
-			AuthHmacAlg:      data.AuthHmacAlg.ValueString(),
-			AuthHeaderKey:    data.AuthHeaderKey.ValueString(),
-			AuthPassword:     data.AuthPassword.ValueString(),
-			AuthSecretValue:  data.AuthSecretValue.ValueString(),
-			AuthMethod:       data.AuthMethod.ValueString(),
-			AuthUsername:     data.AuthUsername.ValueString(),
-			AuthBearerToken:  data.AuthBearerToken.ValueString(),
+			IntegrationLabel:     data.IntegrationLabel.ValueString(),
+			LogStreamType:        data.LogStreamType.ValueString(),
+			LogTypes:             convertLogTypes(ctx, data.LogTypes),
+			LogStreamTypeOptions: logStreamTypeOptions,
+			AuthHmacAlg:          data.AuthHmacAlg.ValueString(),
+			AuthHeaderKey:        data.AuthHeaderKey.ValueString(),
+			AuthPassword:         data.AuthPassword.ValueString(),
+			AuthSecretValue:      data.AuthSecretValue.ValueString(),
+			AuthMethod:           data.AuthMethod.ValueString(),
+			AuthUsername:         data.AuthUsername.ValueString(),
+			AuthBearerToken:      data.AuthBearerToken.ValueString(),
 		},
 	})
 	if err != nil {
@@ -133,6 +172,18 @@ func (r *httpsourceResource) Create(ctx context.Context, req resource.CreateRequ
 		)
 		return
 	}
+
+	tflog.Warn(ctx, "API Response from HTTP Source", map[string]interface{}{
+		"HTTP_SOURCE":             fmt.Sprintf("%+v", httpSource),
+		"LOG_STREAM_TYPE_OPTIONS": fmt.Sprintf("%+v", httpSource.LogStreamTypeOptions),
+	})
+
+	// Log the response
+	tflog.Warn(ctx, "HTTP Source created successfully", map[string]interface{}{
+		"HTTP_SOURCE":                      fmt.Sprintf("%+v", httpSource),
+		"RESPONSE_LOG_STREAM_TYPE_OPTIONS": fmt.Sprintf("%+v", httpSource.LogStreamTypeOptions),
+	})
+
 	data.Id = types.StringValue(httpSource.IntegrationId)
 
 	// Save data into Terraform state
@@ -168,6 +219,47 @@ func (r *httpsourceResource) Read(ctx context.Context, req resource.ReadRequest,
 	data.AuthHeaderKey = types.StringValue(httpSource.AuthHeaderKey)
 	data.AuthUsername = types.StringValue(httpSource.AuthUsername)
 
+	// Warning logging with tflog
+	tflog.Warn(ctx, "API Response from HTTP Source", map[string]interface{}{
+		"HTTP_SOURCE":             fmt.Sprintf("%+v", httpSource),
+		"LOG_STREAM_TYPE_OPTIONS": fmt.Sprintf("%+v", httpSource.LogStreamTypeOptions),
+	})
+
+	// Try a different approach to handle LogStreamTypeOptions
+	var logStreamTypeOptions resource_httpsource.LogStreamTypeOptionsValue
+
+	if httpSource.LogStreamTypeOptions != nil {
+		// Build from the object value method using context
+		attributeTypes := map[string]attr.Type{
+			"json_array_envelope_field": types.StringType,
+		}
+
+		attributeValues := map[string]attr.Value{
+			"json_array_envelope_field": types.StringValue(httpSource.LogStreamTypeOptions.JsonArrayEnvelopeField),
+		}
+
+		// Use NewLogStreamTypeOptionsValue to create the object
+		logStreamTypeOptionsObj, diags := resource_httpsource.NewLogStreamTypeOptionsValue(attributeTypes, attributeValues)
+		if diags.HasError() {
+			resp.Diagnostics.Append(diags...)
+		} else {
+			logStreamTypeOptions = logStreamTypeOptionsObj
+		}
+	} else {
+		// Explicitly use the null constructor
+		logStreamTypeOptions = resource_httpsource.NewLogStreamTypeOptionsValueNull()
+	}
+
+	// After setting the field
+	tflog.Warn(ctx, "LogStreamTypeOptions after setting", map[string]interface{}{
+		"VALUE":      fmt.Sprintf("%+v", data.LogStreamTypeOptions),
+		"IS_NULL":    data.LogStreamTypeOptions.IsNull(),
+		"IS_UNKNOWN": data.LogStreamTypeOptions.IsUnknown(),
+	})
+
+	// Assign the properly constructed object
+	data.LogStreamTypeOptions = logStreamTypeOptions
+
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -182,19 +274,28 @@ func (r *httpsourceResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
+	// Create LogStreamTypeOptions if it's provided
+	var logStreamTypeOptions *client.LogStreamTypeOptions
+	if !data.LogStreamTypeOptions.IsNull() && !data.LogStreamTypeOptions.IsUnknown() {
+		logStreamTypeOptions = &client.LogStreamTypeOptions{
+			JsonArrayEnvelopeField: data.LogStreamTypeOptions.JsonArrayEnvelopeField.ValueString(),
+		}
+	}
+
 	_, err := r.client.UpdateHttpSource(ctx, client.UpdateHttpSourceInput{
 		IntegrationId: data.Id.ValueString(),
 		HttpSourceModifiableAttributes: client.HttpSourceModifiableAttributes{
-			IntegrationLabel: data.IntegrationLabel.ValueString(),
-			LogStreamType:    data.LogStreamType.ValueString(),
-			LogTypes:         convertLogTypes(ctx, data.LogTypes),
-			AuthHmacAlg:      data.AuthHmacAlg.ValueString(),
-			AuthHeaderKey:    data.AuthHeaderKey.ValueString(),
-			AuthPassword:     data.AuthPassword.ValueString(),
-			AuthSecretValue:  data.AuthSecretValue.ValueString(),
-			AuthMethod:       data.AuthMethod.ValueString(),
-			AuthUsername:     data.AuthUsername.ValueString(),
-			AuthBearerToken:  data.AuthBearerToken.ValueString(),
+			IntegrationLabel:     data.IntegrationLabel.ValueString(),
+			LogStreamType:        data.LogStreamType.ValueString(),
+			LogTypes:             convertLogTypes(ctx, data.LogTypes),
+			LogStreamTypeOptions: logStreamTypeOptions,
+			AuthHmacAlg:          data.AuthHmacAlg.ValueString(),
+			AuthHeaderKey:        data.AuthHeaderKey.ValueString(),
+			AuthPassword:         data.AuthPassword.ValueString(),
+			AuthSecretValue:      data.AuthSecretValue.ValueString(),
+			AuthMethod:           data.AuthMethod.ValueString(),
+			AuthUsername:         data.AuthUsername.ValueString(),
+			AuthBearerToken:      data.AuthBearerToken.ValueString(),
 		},
 	})
 	if err != nil {

--- a/internal/provider/httpsource_resource.go
+++ b/internal/provider/httpsource_resource.go
@@ -32,6 +32,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -151,7 +152,9 @@ func (r *httpsourceResource) Create(ctx context.Context, req resource.CreateRequ
 		)
 		return
 	}
-
+	tflog.Debug(ctx, "Created HTTP Source", map[string]any{
+		"id": httpSource.IntegrationId,
+	})
 	data.Id = types.StringValue(httpSource.IntegrationId)
 
 	// Save data into Terraform state
@@ -172,10 +175,13 @@ func (r *httpsourceResource) Read(ctx context.Context, req resource.ReadRequest,
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading HTTP Source",
-			"Could not read HTTP Source, unexpected error: "+err.Error(),
+			fmt.Sprintf("Could not read HTTP Source with id %s, unexpected error: %s", data.Id.ValueString(), err.Error()),
 		)
 		return
 	}
+	tflog.Debug(ctx, "Got HTTP Source", map[string]any{
+		"id": httpSource.IntegrationId,
+	})
 	// We need to set all the values from the API response into the data model, except for the sensitive values
 	// which are returned always as empty strings
 	data.Id = types.StringValue(httpSource.IntegrationId)
@@ -241,10 +247,13 @@ func (r *httpsourceResource) Update(ctx context.Context, req resource.UpdateRequ
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error updating HTTP Source",
-			"Could not update HTTP Source, unexpected error: "+err.Error(),
+			fmt.Sprintf("Could not update HTTP Source with id %s, unexpected error: %s", data.Id.ValueString(), err.Error()),
 		)
 		return
 	}
+	tflog.Debug(ctx, "Updated HTTP Source", map[string]any{
+		"id": data.Id.ValueString(),
+	})
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -264,11 +273,13 @@ func (r *httpsourceResource) Delete(ctx context.Context, req resource.DeleteRequ
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error deleting HTTP Source",
-			"Could not delete HTTP Source, unexpected error: "+err.Error(),
+			fmt.Sprintf("Could not delete HTTP Source with id %s, unexpected error: %s", data.Id.ValueString(), err.Error()),
 		)
 		return
 	}
-
+	tflog.Debug(ctx, "Deleted HTTP Source", map[string]any{
+		"id": data.Id.ValueString(),
+	})
 }
 
 func (r *httpsourceResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/internal/provider/httpsource_resource.go
+++ b/internal/provider/httpsource_resource.go
@@ -137,7 +137,7 @@ func (r *httpsourceResource) Create(ctx context.Context, req resource.CreateRequ
 		},
 	}
 
-	if !data.LogStreamTypeOptions.IsNull() && !data.LogStreamTypeOptions.IsUnknown(){
+	if !data.LogStreamTypeOptions.IsNull() {
 		input.HttpSourceModifiableAttributes.LogStreamTypeOptions = &client.LogStreamTypeOptions{
 			JsonArrayEnvelopeField: data.LogStreamTypeOptions.JsonArrayEnvelopeField.ValueString(),
 		}
@@ -218,20 +218,20 @@ func (r *httpsourceResource) Update(ctx context.Context, req resource.UpdateRequ
 	input := client.UpdateHttpSourceInput{
 		IntegrationId: data.Id.ValueString(),
 		HttpSourceModifiableAttributes: client.HttpSourceModifiableAttributes{
-			IntegrationLabel:     data.IntegrationLabel.ValueString(),
-			LogStreamType:        data.LogStreamType.ValueString(),
-			LogTypes:             convertLogTypes(ctx, data.LogTypes),
-			AuthHmacAlg:          data.AuthHmacAlg.ValueString(),
-			AuthHeaderKey:        data.AuthHeaderKey.ValueString(),
-			AuthPassword:         data.AuthPassword.ValueString(),
-			AuthSecretValue:      data.AuthSecretValue.ValueString(),
-			AuthMethod:           data.AuthMethod.ValueString(),
-			AuthUsername:         data.AuthUsername.ValueString(),
-			AuthBearerToken:      data.AuthBearerToken.ValueString(),
+			IntegrationLabel: data.IntegrationLabel.ValueString(),
+			LogStreamType:    data.LogStreamType.ValueString(),
+			LogTypes:         convertLogTypes(ctx, data.LogTypes),
+			AuthHmacAlg:      data.AuthHmacAlg.ValueString(),
+			AuthHeaderKey:    data.AuthHeaderKey.ValueString(),
+			AuthPassword:     data.AuthPassword.ValueString(),
+			AuthSecretValue:  data.AuthSecretValue.ValueString(),
+			AuthMethod:       data.AuthMethod.ValueString(),
+			AuthUsername:     data.AuthUsername.ValueString(),
+			AuthBearerToken:  data.AuthBearerToken.ValueString(),
 		},
 	}
 
-	if !data.LogStreamTypeOptions.IsNull() && !data.LogStreamTypeOptions.IsUnknown() {
+	if !data.LogStreamTypeOptions.IsNull() {
 		input.HttpSourceModifiableAttributes.LogStreamTypeOptions = &client.LogStreamTypeOptions{
 			JsonArrayEnvelopeField: data.LogStreamTypeOptions.JsonArrayEnvelopeField.ValueString(),
 		}

--- a/internal/provider/httpsource_resource.go
+++ b/internal/provider/httpsource_resource.go
@@ -193,7 +193,7 @@ func (r *httpsourceResource) Read(ctx context.Context, req resource.ReadRequest,
 	data.AuthHeaderKey = types.StringValue(httpSource.AuthHeaderKey)
 	data.AuthUsername = types.StringValue(httpSource.AuthUsername)
 
-	if httpSource.LogStreamTypeOptions != nil && httpSource.LogStreamTypeOptions.JsonArrayEnvelopeField != "" {
+	if httpSource.LogStreamTypeOptions != nil {
 		attributeTypes := map[string]attr.Type{
 			"json_array_envelope_field": types.StringType,
 		}

--- a/internal/provider/httpsource_resource_test.go
+++ b/internal/provider/httpsource_resource_test.go
@@ -77,7 +77,7 @@ func TestHttpSourceResource(t *testing.T) {
 			},
 			// Provide an unchanged configuration and manually delete the resource
 			{
-				Config:      providerConfig + testHttpSourceResourceConfig(integrationUpdatedLabel),
+				Config:      providerConfig + testUpdatedHttpSourceResourceConfig(integrationUpdatedLabel),
 				Check:       manuallyDeleteSource,
 				ExpectError: regexp.MustCompile("Error running post-apply refresh plan"),
 			},
@@ -143,6 +143,5 @@ func manuallyDeleteSource(s *terraform.State) error {
 		time.Sleep(5 * time.Second)
 		retry++
 	}
-
 	return fmt.Errorf("could not delete http source after %d retries", retry)
 }

--- a/internal/provider/httpsource_resource_test.go
+++ b/internal/provider/httpsource_resource_test.go
@@ -19,8 +19,6 @@ package provider
 import (
 	"errors"
 	"fmt"
-	"github.com/google/uuid"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"net/http"
 	"os"
 	"regexp"
@@ -28,6 +26,9 @@ import (
 	"terraform-provider-panther/internal/client/panther"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
@@ -71,6 +72,7 @@ func TestHttpSourceResource(t *testing.T) {
 					resource.TestCheckResourceAttr("panther_httpsource.test", "auth_method", "Basic"),
 					resource.TestCheckResourceAttr("panther_httpsource.test", "auth_username", "foo"),
 					resource.TestCheckResourceAttr("panther_httpsource.test", "auth_password", "bar"),
+					resource.TestCheckResourceAttr("panther_httpsource.test", "log_stream_type_options.json_array_envelope_field", "records"),
 				),
 			},
 			// Provide an unchanged configuration and manually delete the resource
@@ -91,9 +93,9 @@ resource "panther_httpsource" "test" {
   integration_label     = "%v"
   log_stream_type       = "Auto"
   log_types             = ["AWS.CloudFrontAccess"]
-  auth_method         = "SharedSecret"
-  auth_header_key   = "x-api-key"
-  auth_secret_value = "test-secret-value"
+  auth_method           = "SharedSecret"
+  auth_header_key       = "x-api-key"
+  auth_secret_value     = "test-secret-value"
 }
 `, name)
 }
@@ -107,6 +109,9 @@ resource "panther_httpsource" "test" {
   auth_method         = "Basic"
   auth_username   	= "foo"
   auth_password 	= "bar"
+  log_stream_type_options {
+    json_array_envelope_field = "records" 
+  }
 }
 `, name)
 }

--- a/internal/provider/httpsource_resource_test.go
+++ b/internal/provider/httpsource_resource_test.go
@@ -60,7 +60,7 @@ func TestHttpSourceResource(t *testing.T) {
 				ResourceName:            "panther_httpsource.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"auth_secret_value", "auth_password"},
+				ImportStateVerifyIgnore: []string{"auth_secret_value", "auth_password", "auth_bearer_token"},
 			},
 			// Update and Read testing
 			{
@@ -109,7 +109,7 @@ resource "panther_httpsource" "test" {
   auth_method         = "Basic"
   auth_username   	= "foo"
   auth_password 	= "bar"
-  log_stream_type_options {
+  log_stream_type_options = {
     json_array_envelope_field = "records" 
   }
 }

--- a/internal/provider/resource_httpsource/httpsource_resource_gen.go
+++ b/internal/provider/resource_httpsource/httpsource_resource_gen.go
@@ -4,9 +4,15 @@ package resource_httpsource
 
 import (
 	"context"
+	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 )
@@ -89,6 +95,23 @@ func HttpsourceResourceSchema(ctx context.Context) schema.Schema {
 					),
 				},
 			},
+			"log_stream_type_options": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"json_array_envelope_field": schema.StringAttribute{
+						Optional:            true,
+						Computed:            true,
+						Description:         "Path to the array value to extract elements from, only applicable if logStreamType is JsonArray. Leave empty if the input JSON is an array itself",
+						MarkdownDescription: "Path to the array value to extract elements from, only applicable if logStreamType is JsonArray. Leave empty if the input JSON is an array itself",
+					},
+				},
+				CustomType: LogStreamTypeOptionsType{
+					ObjectType: types.ObjectType{
+						AttrTypes: LogStreamTypeOptionsValue{}.AttributeTypes(ctx),
+					},
+				},
+				Optional: true,
+				Computed: true,
+			},
 			"log_types": schema.ListAttribute{
 				ElementType:         types.StringType,
 				Required:            true,
@@ -100,15 +123,340 @@ func HttpsourceResourceSchema(ctx context.Context) schema.Schema {
 }
 
 type HttpsourceModel struct {
-	AuthBearerToken  types.String `tfsdk:"auth_bearer_token"`
-	AuthHeaderKey    types.String `tfsdk:"auth_header_key"`
-	AuthHmacAlg      types.String `tfsdk:"auth_hmac_alg"`
-	AuthMethod       types.String `tfsdk:"auth_method"`
-	AuthPassword     types.String `tfsdk:"auth_password"`
-	AuthSecretValue  types.String `tfsdk:"auth_secret_value"`
-	AuthUsername     types.String `tfsdk:"auth_username"`
-	Id               types.String `tfsdk:"id"`
-	IntegrationLabel types.String `tfsdk:"integration_label"`
-	LogStreamType    types.String `tfsdk:"log_stream_type"`
-	LogTypes         types.List   `tfsdk:"log_types"`
+	AuthBearerToken      types.String              `tfsdk:"auth_bearer_token"`
+	AuthHeaderKey        types.String              `tfsdk:"auth_header_key"`
+	AuthHmacAlg          types.String              `tfsdk:"auth_hmac_alg"`
+	AuthMethod           types.String              `tfsdk:"auth_method"`
+	AuthPassword         types.String              `tfsdk:"auth_password"`
+	AuthSecretValue      types.String              `tfsdk:"auth_secret_value"`
+	AuthUsername         types.String              `tfsdk:"auth_username"`
+	Id                   types.String              `tfsdk:"id"`
+	IntegrationLabel     types.String              `tfsdk:"integration_label"`
+	LogStreamType        types.String              `tfsdk:"log_stream_type"`
+	LogStreamTypeOptions LogStreamTypeOptionsValue `tfsdk:"log_stream_type_options"`
+	LogTypes             types.List                `tfsdk:"log_types"`
+}
+
+var _ basetypes.ObjectTypable = LogStreamTypeOptionsType{}
+
+type LogStreamTypeOptionsType struct {
+	basetypes.ObjectType
+}
+
+func (t LogStreamTypeOptionsType) Equal(o attr.Type) bool {
+	other, ok := o.(LogStreamTypeOptionsType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t LogStreamTypeOptionsType) String() string {
+	return "LogStreamTypeOptionsType"
+}
+
+func (t LogStreamTypeOptionsType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributes := in.Attributes()
+
+	jsonArrayEnvelopeFieldAttribute, ok := attributes["json_array_envelope_field"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`json_array_envelope_field is missing from object`)
+
+		return nil, diags
+	}
+
+	jsonArrayEnvelopeFieldVal, ok := jsonArrayEnvelopeFieldAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`json_array_envelope_field expected to be basetypes.StringValue, was: %T`, jsonArrayEnvelopeFieldAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return LogStreamTypeOptionsValue{
+		JsonArrayEnvelopeField: jsonArrayEnvelopeFieldVal,
+		state:                  attr.ValueStateKnown,
+	}, diags
+}
+
+func NewLogStreamTypeOptionsValueNull() LogStreamTypeOptionsValue {
+	return LogStreamTypeOptionsValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewLogStreamTypeOptionsValueUnknown() LogStreamTypeOptionsValue {
+	return LogStreamTypeOptionsValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewLogStreamTypeOptionsValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (LogStreamTypeOptionsValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing LogStreamTypeOptionsValue Attribute Value",
+				"While creating a LogStreamTypeOptionsValue value, a missing attribute value was detected. "+
+					"A LogStreamTypeOptionsValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("LogStreamTypeOptionsValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid LogStreamTypeOptionsValue Attribute Type",
+				"While creating a LogStreamTypeOptionsValue value, an invalid attribute value was detected. "+
+					"A LogStreamTypeOptionsValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("LogStreamTypeOptionsValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("LogStreamTypeOptionsValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra LogStreamTypeOptionsValue Attribute Value",
+				"While creating a LogStreamTypeOptionsValue value, an extra attribute value was detected. "+
+					"A LogStreamTypeOptionsValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra LogStreamTypeOptionsValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewLogStreamTypeOptionsValueUnknown(), diags
+	}
+
+	jsonArrayEnvelopeFieldAttribute, ok := attributes["json_array_envelope_field"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`json_array_envelope_field is missing from object`)
+
+		return NewLogStreamTypeOptionsValueUnknown(), diags
+	}
+
+	jsonArrayEnvelopeFieldVal, ok := jsonArrayEnvelopeFieldAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`json_array_envelope_field expected to be basetypes.StringValue, was: %T`, jsonArrayEnvelopeFieldAttribute))
+	}
+
+	if diags.HasError() {
+		return NewLogStreamTypeOptionsValueUnknown(), diags
+	}
+
+	return LogStreamTypeOptionsValue{
+		JsonArrayEnvelopeField: jsonArrayEnvelopeFieldVal,
+		state:                  attr.ValueStateKnown,
+	}, diags
+}
+
+func NewLogStreamTypeOptionsValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) LogStreamTypeOptionsValue {
+	object, diags := NewLogStreamTypeOptionsValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewLogStreamTypeOptionsValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t LogStreamTypeOptionsType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewLogStreamTypeOptionsValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewLogStreamTypeOptionsValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewLogStreamTypeOptionsValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewLogStreamTypeOptionsValueMust(LogStreamTypeOptionsValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t LogStreamTypeOptionsType) ValueType(ctx context.Context) attr.Value {
+	return LogStreamTypeOptionsValue{}
+}
+
+var _ basetypes.ObjectValuable = LogStreamTypeOptionsValue{}
+
+type LogStreamTypeOptionsValue struct {
+	JsonArrayEnvelopeField basetypes.StringValue `tfsdk:"json_array_envelope_field"`
+	state                  attr.ValueState
+}
+
+func (v LogStreamTypeOptionsValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 1)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["json_array_envelope_field"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 1)
+
+		val, err = v.JsonArrayEnvelopeField.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["json_array_envelope_field"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v LogStreamTypeOptionsValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v LogStreamTypeOptionsValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v LogStreamTypeOptionsValue) String() string {
+	return "LogStreamTypeOptionsValue"
+}
+
+func (v LogStreamTypeOptionsValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"json_array_envelope_field": basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"json_array_envelope_field": v.JsonArrayEnvelopeField,
+		})
+
+	return objVal, diags
+}
+
+func (v LogStreamTypeOptionsValue) Equal(o attr.Value) bool {
+	other, ok := o.(LogStreamTypeOptionsValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.JsonArrayEnvelopeField.Equal(other.JsonArrayEnvelopeField) {
+		return false
+	}
+
+	return true
+}
+
+func (v LogStreamTypeOptionsValue) Type(ctx context.Context) attr.Type {
+	return LogStreamTypeOptionsType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v LogStreamTypeOptionsValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"json_array_envelope_field": basetypes.StringType{},
+	}
 }

--- a/provider-code-spec.json
+++ b/provider-code-spec.json
@@ -95,6 +95,21 @@
 						}
 					},
 					{
+						"name": "log_stream_type_options",
+						"single_nested": {
+							"computed_optional_required": "computed_optional",
+							"attributes": [
+								{
+									"name": "json_array_envelope_field",
+									"string": {
+										"computed_optional_required": "computed_optional",
+										"description": "Path to the array value to extract elements from, only applicable if logStreamType is JsonArray. Leave empty if the input JSON is an array itself"
+									}
+								}
+							]
+						}
+					},
+					{
 						"name": "log_types",
 						"list": {
 							"computed_optional_required": "required",


### PR DESCRIPTION
### Background

We introduced a new field in https://github.com/panther-labs/panther-enterprise/pull/21480 in order to support `Azure Event Hub` format for logs with an envelope field, making it customisable. This comprised, among others, changes in `source-api` model and `rest-api` model.

### Changes

This PR is updating the provider http source resource to account for this new field.

### Testing

Updated integration test to use the new field when updating the resource.

Tested in dev env. The test includes deploying [this](https://github.com/panther-labs/panther-enterprise/pull/22121) change in the rest api.

Update the resource definition in full-examples:

<img width="600" alt="Screenshot 2025-03-19 at 4 03 47 PM" src="https://github.com/user-attachments/assets/8c111e89-3f9e-4295-8e19-b71ae94927a2" />

Run plan and apply:

<img width="600" alt="Screenshot 2025-03-19 at 4 04 24 PM" src="https://github.com/user-attachments/assets/ad81b440-c44f-4772-a63e-2d1b1304408d" />

Validate through a GET to a rest-api:

<img width="600" alt="Screenshot 2025-03-19 at 4 08 04 PM" src="https://github.com/user-attachments/assets/1324f12e-b293-4def-83e0-b6a2f52e54c3" />

Update resource definition to not have the envelope field:

<img width="600" alt="Screenshot 2025-03-19 at 4 11 00 PM" src="https://github.com/user-attachments/assets/5b4fda98-ad59-4e53-8adc-b6fe9453b500" />

Run plan and apply:

<img width="600" alt="Screenshot 2025-03-19 at 4 11 26 PM" src="https://github.com/user-attachments/assets/acd18f48-2bdc-4995-962b-e7105322e6a0" />

Check with GET that the envelope field is gone:

<img width="600" alt="Screenshot 2025-03-19 at 4 11 32 PM" src="https://github.com/user-attachments/assets/4f025f6c-c7e4-4b2f-b847-2dd6285e8e30" />

As a last check, we destroy the resource and create it from scratch without envelope field to make sure that the plan does not contain the envelope field at all:

<img width="600" alt="Screenshot 2025-03-19 at 4 13 19 PM" src="https://github.com/user-attachments/assets/a61e4ca8-fd84-4d34-991f-aa33b97432ef" />
  
