### PR TITLE
Update HTTP TF log_stream_type description

### DIFF
--- a/internal/provider/resource_httpsource/httpsource_resource_gen.go
+++ b/internal/provider/resource_httpsource/httpsource_resource_gen.go
@@ -83,8 +83,8 @@ func HttpsourceResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"log_stream_type": schema.StringAttribute{
 				Required:            true,
-				Description:         "The log stream type",
-				MarkdownDescription: "The log stream type",
+				Description:         "The format of the log files being ingested. Supported log stream types: Auto, JSON, JsonArray, Lines, CloudWatchLogs",
+				MarkdownDescription: "The format of the log files being ingested. Supported log stream types: Auto, JSON, JsonArray, Lines, CloudWatchLogs",
 				Validators: []validator.String{
 					stringvalidator.OneOf(
 						"Auto",


### PR DESCRIPTION
Customer requested an update of the description to include the accepted log stream types.

### Ticket
https://panther-labs.slack.com/archives/C04N775LVPB/p1749743018198289

### Changes

* Modified `log_stream_type` description to: "The format of the log files being ingested. Supported log stream types: Auto, JSON, JsonArray, Lines, CloudWatchLogs"
