### PR TITLE
Update S3 TF log_stream_type description

### DIFF
--- a/docs/resources/s3_source.md
+++ b/docs/resources/s3_source.md
@@ -38,7 +38,7 @@ resource "panther_s3_source" "test_source" {
 - `aws_account_id` (String) The ID of the AWS Account where the S3 Bucket is located.
 - `bucket_name` (String) The name of the S3 Bucket where logs will be ingested from.
 - `log_processing_role_arn` (String) The AWS Role used to access the S3 Bucket.
-- `log_stream_type` (String) The format of the log files being ingested.
+- `log_stream_type` (String) The format of the log files being ingested. Supported log stream types: Auto, JSON, JsonArray, Lines, CloudWatchLogs
 - `name` (String) The display name of the S3 Log Source integration.
 - `prefix_log_types` (Attributes List) The configured mapping of prefixes to log types. (see [below for nested schema](#nestedatt--prefix_log_types))
 

--- a/internal/provider/resource_s3_source.go
+++ b/internal/provider/resource_s3_source.go
@@ -107,7 +107,7 @@ func (r *S3SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				Required:    true,
 			},
 			"log_stream_type": schema.StringAttribute{
-				Description: "The format of the log files being ingested.",
+				Description: "The format of the log files being ingested. Supported log stream types: Auto, JSON, JsonArray, Lines, CloudWatchLogs",
 				Required:    true,
 				Validators: []validator.String{
 					stringvalidator.OneOf("Auto", "Lines", "JSON", "JsonArray", "CloudWatchLogs"),


### PR DESCRIPTION
Customer requested an update of the description to include the accepted log stream types.

### Ticket

https://panther-labs.slack.com/archives/C04N775LVPB/p1749743018198289

### Changes

- Modified `log_stream_type` description to: "The format of the log files being ingested. Supported log stream types: Auto, JSON, JsonArray, Lines, CloudWatchLogs"
