### PR TITLE
add xml stream type

### DIFF
--- a/docs/resources/httpsource.md
+++ b/docs/resources/httpsource.md
@@ -35,7 +35,7 @@ resource "panther_httpsource" "example_http_source" {
 
 - `auth_method` (String) The authentication method of the http source
 - `integration_label` (String) The integration label (name)
-- `log_stream_type` (String) The log stream type. Supported log stream types: Auto, JSON, JsonArray, Lines, CloudWatchLogs
+- `log_stream_type` (String) The log stream type. Supported log stream types: Auto, JSON, JsonArray, Lines, CloudWatchLogs, XML
 - `log_types` (List of String) The log types of the integration
 
 ### Optional

--- a/docs/resources/s3_source.md
+++ b/docs/resources/s3_source.md
@@ -38,7 +38,7 @@ resource "panther_s3_source" "test_source" {
 - `aws_account_id` (String) The ID of the AWS Account where the S3 Bucket is located.
 - `bucket_name` (String) The name of the S3 Bucket where logs will be ingested from.
 - `log_processing_role_arn` (String) The AWS Role used to access the S3 Bucket.
-- `log_stream_type` (String) The format of the log files being ingested. Supported log stream types: Auto, JSON, JsonArray, Lines, CloudWatchLogs
+- `log_stream_type` (String) The format of the log files being ingested. Supported log stream types: Auto, JSON, JsonArray, Lines, CloudWatchLogs, XML
 - `name` (String) The display name of the S3 Log Source integration.
 - `prefix_log_types` (Attributes List) The configured mapping of prefixes to log types. (see [below for nested schema](#nestedatt--prefix_log_types))
 

--- a/internal/provider/resource_httpsource/httpsource_resource_gen.go
+++ b/internal/provider/resource_httpsource/httpsource_resource_gen.go
@@ -83,8 +83,8 @@ func HttpsourceResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"log_stream_type": schema.StringAttribute{
 				Required:            true,
-				Description:         "The log stream type. Supported log stream types: Auto, JSON, JsonArray, Lines, CloudWatchLogs",
-				MarkdownDescription: "The log stream type. Supported log stream types: Auto, JSON, JsonArray, Lines, CloudWatchLogs",
+				Description:         "The log stream type. Supported log stream types: Auto, JSON, JsonArray, Lines, CloudWatchLogs, XML",
+				MarkdownDescription: "The log stream type. Supported log stream types: Auto, JSON, JsonArray, Lines, CloudWatchLogs, XML",
 				Validators: []validator.String{
 					stringvalidator.OneOf(
 						"Auto",
@@ -92,6 +92,7 @@ func HttpsourceResourceSchema(ctx context.Context) schema.Schema {
 						"JsonArray",
 						"Lines",
 						"CloudWatchLogs",
+						"XML",
 					),
 				},
 			},

--- a/internal/provider/resource_s3_source.go
+++ b/internal/provider/resource_s3_source.go
@@ -107,10 +107,10 @@ func (r *S3SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				Required:    true,
 			},
 			"log_stream_type": schema.StringAttribute{
-				Description: "The format of the log files being ingested. Supported log stream types: Auto, JSON, JsonArray, Lines, CloudWatchLogs",
+				Description: "The format of the log files being ingested. Supported log stream types: Auto, JSON, JsonArray, Lines, CloudWatchLogs, XML",
 				Required:    true,
 				Validators: []validator.String{
-					stringvalidator.OneOf("Auto", "Lines", "JSON", "JsonArray", "CloudWatchLogs"),
+					stringvalidator.OneOf("Auto", "Lines", "JSON", "JsonArray", "CloudWatchLogs", "XML"),
 				},
 			},
 			"panther_managed_bucket_notifications_enabled": schema.BoolAttribute{

--- a/provider-code-spec.json
+++ b/provider-code-spec.json
@@ -79,7 +79,7 @@
 						"name": "log_stream_type",
 						"string": {
 							"computed_optional_required": "required",
-							"description": "The log stream type. Supported log stream types: Auto, JSON, JsonArray, Lines, CloudWatchLogs",
+							"description": "The log stream type. Supported log stream types: Auto, JSON, JsonArray, Lines, CloudWatchLogs, XML",
 							"validators": [
 								{
 									"custom": {
@@ -88,7 +88,7 @@
 												"path": "github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 											}
 										],
-										"schema_definition": "stringvalidator.OneOf(\n\"Auto\",\n\"JSON\",\n\"JsonArray\",\n\"Lines\",\n\"CloudWatchLogs\",\n)"
+										"schema_definition": "stringvalidator.OneOf(\n\"Auto\",\n\"JSON\",\n\"JsonArray\",\n\"Lines\",\n\"CloudWatchLogs\",\n\"XML\",\n)"
 									}
 								}
 							]


### PR DESCRIPTION
### Background

We have added the possibility to select `XML` stream type for log sources, so this PR is to update the provider to use this functionality as well.

### Changes

Adds XML as a stream type for S3 and http source resources and relevant docs.

### Testing

Tested with `full-examples` folder and running tf commands:

S3

Create s3 source resource with xml stream type:

<img width="608" alt="Screenshot 2025-07-08 at 2 25 45 PM" src="https://github.com/user-attachments/assets/53016427-3614-4f47-865a-87578c40410d" />

Run tf apply:

<img width="600" alt="Screenshot 2025-07-08 at 2 26 25 PM" src="https://github.com/user-attachments/assets/acca77f4-b260-495c-a8cb-363eb524ea88" />

Source in Panther console:

<img width="600" alt="Screenshot 2025-07-08 at 2 26 52 PM" src="https://github.com/user-attachments/assets/ac807e47-47f0-4974-83ae-4f40b2eb7869" />

http:

Create http source resource with xml:

<img width="473" alt="Screenshot 2025-07-08 at 7 21 33 PM" src="https://github.com/user-attachments/assets/8817954e-90cf-4b49-a9fa-91424b80cb0e" />

Run tf apply:

<img width="600" alt="Screenshot 2025-07-08 at 2 30 54 PM" src="https://github.com/user-attachments/assets/acc1fd7b-c642-4778-918f-071fbf36eb1a" />

<img width="600" alt="Screenshot 2025-07-08 at 7 22 08 PM" src="https://github.com/user-attachments/assets/fe2d1709-696b-4446-bf53-7824471b000c" />







