### PR TITLE
Improve release pipeline: github-native changelog, pin goreleaser-action v7.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,23 +17,25 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # Allow goreleaser to access older tag information.
           fetch-depth: 0
-      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
           cache: true
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
         id: import_gpg
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7.0.0
+        uses: goreleaser/goreleaser-action@e24998b8b67b290c2fa8b7c14fcfa7de2c5c9b8c # v7.1.0
         with:
+          distribution: goreleaser
+          version: '~> v2'
           args: release --clean
         env:
           # GitHub sets the GITHUB_TOKEN secret automatically.

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -58,5 +58,5 @@ release:
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
 changelog:
-  disable: true
+  use: github-native
 


### PR DESCRIPTION
## Summary

- `.goreleaser.yml`: enable `changelog.use: github-native` (was disabled) so release notes auto-populate from GitHub's "Generate release notes" API. v0.2.10's notes were sparse because of this.
- `release.yml`: bump `goreleaser-action` from `@v7.0.0` to SHA-pinned `@v7.1.0`, and `actions/setup-go` from v6.3.0 to v6.4.0 (also SHA-pinned).
- `release.yml`: set `distribution: goreleaser` and `version: '~> v2'` on goreleaser-action to stay on GoReleaser v2.x.
- `release.yml`: add `# vX.Y.Z` comments on each SHA-pinned action.