### PR TITLE
feat: send custom User-Agent on outbound HTTP requests

### DIFF
--- a/internal/client/rest.go
+++ b/internal/client/rest.go
@@ -30,10 +30,10 @@ import (
 const graphQLPath = "/public/graphql"
 
 // NewRESTClient creates a configured REST client for the Panther API.
-func NewRESTClient(url, token string) *RESTClient {
+func NewRESTClient(url, token, userAgent string) *RESTClient {
 	// Strip the legacy /public/graphql suffix — older provider configs included it.
 	pantherURL := strings.TrimSuffix(url, graphQLPath)
-	httpClient := newHTTPClient(token)
+	httpClient := newHTTPClient(token, userAgent)
 
 	return &RESTClient{
 		Doer:    httpClient,

--- a/internal/client/rest_test.go
+++ b/internal/client/rest_test.go
@@ -332,7 +332,7 @@ func TestNewRESTClient_StripsGraphQLSuffix(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := NewRESTClient(tt.input, "token")
+			c := NewRESTClient(tt.input, "token", "ua")
 			assert.Equal(t, tt.wantURL, c.BaseURL)
 		})
 	}

--- a/internal/client/transport.go
+++ b/internal/client/transport.go
@@ -17,32 +17,44 @@ limitations under the License.
 package client
 
 import (
+	"fmt"
 	"net/http"
 	"time"
 )
 
 type authTransport struct {
-	token string
-	next  http.RoundTripper
+	token     string
+	userAgent string
+	next      http.RoundTripper
 }
 
 func (t *authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	r := req.Clone(req.Context())
 	r.Header.Set("X-API-Key", t.token)
+	r.Header.Set("User-Agent", t.userAgent)
 	if r.Body != nil {
 		r.Header.Set("Content-Type", "application/json")
 	}
 	return t.next.RoundTrip(r)
 }
 
-// newHTTPClient returns an *http.Client that satisfies Doer,
-// injecting the API key and Content-Type headers on every request.
-func newHTTPClient(token string) *http.Client {
+func BuildUserAgent(providerVersion, terraformVersion string) string {
+	if providerVersion == "" {
+		providerVersion = "dev"
+	}
+	if terraformVersion == "" {
+		terraformVersion = "unknown"
+	}
+	return fmt.Sprintf("Terraform/%s terraform-provider-panther/%s", terraformVersion, providerVersion)
+}
+
+func newHTTPClient(token, userAgent string) *http.Client {
 	return &http.Client{
 		Timeout: 30 * time.Second,
 		Transport: &authTransport{
-			token: token,
-			next:  http.DefaultTransport,
+			token:     token,
+			userAgent: userAgent,
+			next:      http.DefaultTransport,
 		},
 	}
 }

--- a/internal/client/transport_test.go
+++ b/internal/client/transport_test.go
@@ -19,6 +19,7 @@ package client
 import (
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -101,6 +102,65 @@ func TestAuthTransport_PassesThroughErrors(t *testing.T) {
 }
 
 func TestNewHTTPClient_Timeout(t *testing.T) {
-	client := newHTTPClient("token")
+	client := newHTTPClient("token", "ua")
 	assert.Equal(t, 30*time.Second, client.Timeout)
+}
+
+func TestBuildUserAgent_FormatAndFallbacks(t *testing.T) {
+	tests := []struct {
+		name             string
+		providerVersion  string
+		terraformVersion string
+		want             string
+	}{
+		{
+			name:             "Populated",
+			providerVersion:  "0.5.2",
+			terraformVersion: "1.10.4",
+			want:             "Terraform/1.10.4 terraform-provider-panther/0.5.2",
+		},
+		{
+			name:             "EmptyProviderVersionFallsBackToDev",
+			providerVersion:  "",
+			terraformVersion: "1.10.4",
+			want:             "Terraform/1.10.4 terraform-provider-panther/dev",
+		},
+		{
+			name:             "EmptyTerraformVersionFallsBackToUnknown",
+			providerVersion:  "0.5.2",
+			terraformVersion: "",
+			want:             "Terraform/unknown terraform-provider-panther/0.5.2",
+		},
+		{
+			name:             "DevLiteral",
+			providerVersion:  "dev",
+			terraformVersion: "1.10.4",
+			want:             "Terraform/1.10.4 terraform-provider-panther/dev",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, BuildUserAgent(tt.providerVersion, tt.terraformVersion))
+		})
+	}
+}
+
+func TestAuthTransport_SetsUserAgentOnWire(t *testing.T) {
+	const wantUA = "Terraform/1.10.4 terraform-provider-panther/0.5.2"
+
+	var gotUA string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUA = r.Header.Get("User-Agent")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	c := newHTTPClient("token", wantUA)
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+	resp, err := c.Do(req)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	assert.Equal(t, wantUA, gotUA)
 }

--- a/internal/provider/aws_cloud_account_resource_test.go
+++ b/internal/provider/aws_cloud_account_resource_test.go
@@ -219,7 +219,7 @@ func hclList(items []string) string {
 // in the final state is gone server-side after the framework's auto-destroy step,
 // mirroring checkS3SourceDestroyed in s3source_resource_test.go.
 func checkAwsCloudAccountDestroyed(s *terraform.State) error {
-	c := client.NewRESTClient(os.Getenv("PANTHER_API_URL"), os.Getenv("PANTHER_API_TOKEN"))
+	c := client.NewRESTClient(os.Getenv("PANTHER_API_URL"), os.Getenv("PANTHER_API_TOKEN"), testUserAgent)
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "panther_aws_cloud_account" {
 			continue

--- a/internal/provider/helpers_test.go
+++ b/internal/provider/helpers_test.go
@@ -38,6 +38,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const testUserAgent = "Terraform/test terraform-provider-panther/test"
+
 func TestRestClient_NilProviderData(t *testing.T) {
 	req := resource.ConfigureRequest{ProviderData: nil}
 	resp := &resource.ConfigureResponse{}

--- a/internal/provider/httpsource_resource_test.go
+++ b/internal/provider/httpsource_resource_test.go
@@ -133,7 +133,7 @@ func manuallyDeleteSource(t *testing.T, resourceName, basePath string) resource.
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("%s ID is not set", resourceName)
 		}
-		c := client.NewRESTClient(os.Getenv("PANTHER_API_URL"), os.Getenv("PANTHER_API_TOKEN"))
+		c := client.NewRESTClient(os.Getenv("PANTHER_API_URL"), os.Getenv("PANTHER_API_TOKEN"), testUserAgent)
 		path := basePath + "/" + rs.Primary.ID
 		const maxRetries = 10
 		for retry := 0; retry < maxRetries; retry++ {

--- a/internal/provider/log_source_alarm_resource_test.go
+++ b/internal/provider/log_source_alarm_resource_test.go
@@ -257,7 +257,7 @@ func manuallyDeleteLogSourceAlarm(t *testing.T) resource.TestCheckFunc {
 		}
 		// rs.Primary.ID is the composite "{source_id}/SOURCE_NO_DATA", exactly the
 		// path suffix the API expects — concat and DELETE.
-		c := client.NewRESTClient(os.Getenv("PANTHER_API_URL"), os.Getenv("PANTHER_API_TOKEN"))
+		c := client.NewRESTClient(os.Getenv("PANTHER_API_URL"), os.Getenv("PANTHER_API_TOKEN"), testUserAgent)
 		if err := client.RestDelete(context.Background(), c, logSourceAlarmPath+"/"+rs.Primary.ID); err != nil {
 			return fmt.Errorf("could not delete alarm: %w", err)
 		}
@@ -271,7 +271,7 @@ func manuallyDeleteLogSourceAlarm(t *testing.T) resource.TestCheckFunc {
 // silent-failure window where Delete returns no diagnostic but the alarm still exists
 // remotely. Mirrors checkS3SourceDestroyed in s3source_resource_test.go.
 func checkLogSourceAlarmDestroyed(s *terraform.State) error {
-	c := client.NewRESTClient(os.Getenv("PANTHER_API_URL"), os.Getenv("PANTHER_API_TOKEN"))
+	c := client.NewRESTClient(os.Getenv("PANTHER_API_URL"), os.Getenv("PANTHER_API_TOKEN"), testUserAgent)
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "panther_log_source_alarm" {
 			continue

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -122,7 +122,8 @@ func (p *PantherProvider) Configure(ctx context.Context, req provider.ConfigureR
 		return
 	}
 
-	resp.ResourceData = client.NewRESTClient(url, token)
+	userAgent := client.BuildUserAgent(p.version, req.TerraformVersion)
+	resp.ResourceData = client.NewRESTClient(url, token, userAgent)
 }
 
 func (p *PantherProvider) Resources(ctx context.Context) []func() resource.Resource {

--- a/internal/provider/s3source_resource_test.go
+++ b/internal/provider/s3source_resource_test.go
@@ -161,7 +161,7 @@ func manuallyDeleteS3Source(t *testing.T) resource.TestCheckFunc {
 		if rs.Primary.ID == "" {
 			return errors.New("S3 source ID is not set")
 		}
-		c := client.NewRESTClient(os.Getenv("PANTHER_API_URL"), os.Getenv("PANTHER_API_TOKEN"))
+		c := client.NewRESTClient(os.Getenv("PANTHER_API_URL"), os.Getenv("PANTHER_API_TOKEN"), testUserAgent)
 		if err := client.RestDelete(context.Background(), c, s3SourcePath+"/"+rs.Primary.ID); err != nil {
 			return fmt.Errorf("could not delete S3 source: %w", err)
 		}
@@ -174,7 +174,7 @@ func manuallyDeleteS3Source(t *testing.T) resource.TestCheckFunc {
 // test state has actually been removed from the Panther API — closes the silent-failure
 // window where Delete() returns no diagnostic but the resource still exists remotely.
 func checkS3SourceDestroyed(s *terraform.State) error {
-	c := client.NewRESTClient(os.Getenv("PANTHER_API_URL"), os.Getenv("PANTHER_API_TOKEN"))
+	c := client.NewRESTClient(os.Getenv("PANTHER_API_URL"), os.Getenv("PANTHER_API_TOKEN"), testUserAgent)
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "panther_s3_source" {
 			continue


### PR DESCRIPTION
Every outbound HTTP request from the provider now carries a `User-Agent` header identifying it as Terraform-Panther provider traffic, so the Panther API can distinguish provider-driven requests from other clients for observability and traffic analysis.

### What's on the wire

```
Terraform/<terraform-cli-version> terraform-provider-panther/<provider-version>
```

- **Provider version** — goreleaser-injected [`main.version`](https://github.com/panther-labs/terraform-provider-panther/blob/4876b72dd69409d2fda2b4fb10069ee6cd7b8983/main.go#L41) ldflag at release time; falls back to `"dev"` on plain `go build`.
- **Terraform CLI version** — [`req.TerraformVersion`](https://github.com/hashicorp/terraform-plugin-framework/blob/v1.12.0/provider/configure.go#L32) on the Plugin Framework's `ConfigureRequest`, populated by the Terraform CLI over the plugin gRPC protocol on each invocation; we consume it in [`provider.go`](https://github.com/panther-labs/terraform-provider-panther/blob/4876b72dd69409d2fda2b4fb10069ee6cd7b8983/internal/provider/provider.go#L125). Falls back to `"unknown"` if absent.

A `v0.5.2` binary on Terraform 1.14.6 emits `Terraform/1.14.6 terraform-provider-panther/0.5.2`. The customer upgrading their CLI to 1.15.0 next week emits `Terraform/1.15.0 ...` automatically — no provider rebuild needed.

### Format follows the aws / google / azurerm convention

`Terraform/<v> terraform-provider-panther/<v>` — same two-product-token shape as:

- [terraform-provider-aws](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/conns/config.go)
- [terraform-provider-google](https://github.com/hashicorp/terraform-provider-google/blob/main/google/fwtransport/framework_utils.go)
- [terraform-provider-azurerm](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/internal/common/client_options.go)


